### PR TITLE
#22 Incorrect Dockerfile for Ubuntu - the GID=1000 is already used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ FROM eclipse-temurin:17
 
 ENV APP_BUILD_DIR=/opt/build
 
-RUN groupadd --gid 1000 wasp \
-  && useradd --uid 1000 --gid wasp --shell /bin/bash --create-home wasp-core
+RUN groupadd wasp \
+  && useradd --gid wasp --shell /bin/bash --create-home wasp-core
 USER wasp-core:wasp
 WORKDIR /opt/wasp-core
 

--- a/wasp-core/pom.xml
+++ b/wasp-core/pom.xml
@@ -10,9 +10,9 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>wasp-ng-core</artifactId>
+  <artifactId>wasp-core</artifactId>
   <version>0.0.1-SNAPSHOT</version>
-  <name>wasp-ng-core</name>
+  <name>wasp-core</name>
   <description>WASP NG Core module</description>
 
   <build>


### PR DESCRIPTION
Fixed the artifact name and removed UID and GID numbers.