### PR TITLE
#38 Add new configuration parameter to enable/disable RADIUS-authentication

### DIFF
--- a/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/controller/DefaultController.java
+++ b/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/controller/DefaultController.java
@@ -4,6 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
 @Controller
@@ -33,7 +35,7 @@ public class DefaultController {
         return new ModelAndView("access-denied-view");
     }
 
-    @PostMapping("/home")
+    @RequestMapping(value = "/home", method = {RequestMethod.GET, RequestMethod.POST})
     public ModelAndView home() {
         log.info("DefaultController: home()");
         return new ModelAndView("home-view");

--- a/wasp-core/src/main/resources/application.properties
+++ b/wasp-core/src/main/resources/application.properties
@@ -6,21 +6,18 @@ spring.profiles.active=@spring.profiles.active@
 # App settings
 #
 spring.application.name=wasp-ng-core
-
 git.commitIdAbbrev=@git.commit.id.abbrev@
 git.branch=@git.branch@
 git.buildTime=@git.build.time@
 git.buildVersion=@git.build.version@
 git.tags=@git.tags@
-
 wasp.core.db.schema=${WASP_CORE_DB_SCHEMA:core}
-
-wasp.radius.ip=${WASP_RADIUS_IP:10.122.33.14}
+wasp.radius.auth.enabled=${WASP_RADIUS_AUTH_ENABLED:false}
+wasp.radius.ip=${WASP_RADIUS_IP:}
 wasp.radius.port=${WASP_RADIUS_PORT:1812}
-wasp.radius.secret=${WASP_RADIUS_SECRET:iugYFTVlhjbQMPlkjguh}
+wasp.radius.secret=${WASP_RADIUS_SECRET:}
 wasp.radius.nas.identifier=${WASP_RADIUS_NAS_IDENTIFIER:wasp}
-wasp.radius.nas.ip=${WASP_RADIUS_NAS_IP:62.76.223.148}
-
+wasp.radius.nas.ip=${WASP_RADIUS_NAS_IP:}
 #
 # Spring Security settings
 #

--- a/wasp-core/src/test/java/ru/vsu/uic/wasp/ng/core/SecurityAnonymousTest.java
+++ b/wasp-core/src/test/java/ru/vsu/uic/wasp/ng/core/SecurityAnonymousTest.java
@@ -41,7 +41,7 @@ public class SecurityAnonymousTest {
     void anonymousUserHasAccessToDefaultStartPage() throws Exception {
         this.mvc.perform(MockMvcRequestBuilders.get("/"))
                 .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.content().string(containsString("Public Page")))
+                .andExpect(MockMvcResultMatchers.content().string(containsString("Try to login")))
                 .andDo(MockMvcResultHandlers.print());
     }
 


### PR DESCRIPTION
Added the configuration parameter wasp.radius.auth.enabled with default value 'false'. Fixed unit tests.