### PR TITLE
#33 Use HashiCorp Vault to store sensitive information

### DIFF
--- a/docker/vault/vault-docker-compose.yaml
+++ b/docker/vault/vault-docker-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  vault:
+    container_name: "dev-vault"
+    image: hashicorp/vault:latest
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: "wasp"
+    ports:
+      - "8200:8200"

--- a/pom.xml
+++ b/pom.xml
@@ -36,24 +36,6 @@
 		<url/>
 	</scm>
 
-	<profiles>
-		<profile>
-			<id>local</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<properties>
-				<spring.profiles.active>local</spring.profiles.active>
-			</properties>
-		</profile>
-		<profile>
-			<id>docker</id>
-			<properties>
-				<spring.profiles.active>docker</spring.profiles.active>
-			</properties>
-		</profile>
-	</profiles>
-
 	<properties>
 		<java.version>17</java.version>
 	</properties>
@@ -67,18 +49,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<!--
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-freemarker</artifactId>
-		</dependency>
-		-->
-		<!--
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-thymeleaf</artifactId>
-		</dependency>
-		-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
@@ -100,7 +70,10 @@
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-vault-config</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
@@ -114,6 +87,7 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -140,6 +114,18 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>2023.0.3</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<plugins>

--- a/wasp-core/pom.xml
+++ b/wasp-core/pom.xml
@@ -15,6 +15,11 @@
   <name>wasp-core</name>
   <description>WASP NG Core module</description>
 
+  <properties>
+    <version.thymeleaf>3.1.2.RELEASE</version.thymeleaf>
+    <version.aaa4j>0.3.0</version.aaa4j>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -23,12 +28,12 @@
     <dependency>
       <groupId>org.thymeleaf.extras</groupId>
       <artifactId>thymeleaf-extras-springsecurity6</artifactId>
-      <version>3.1.2.RELEASE</version>
+      <version>${version.thymeleaf}</version>
     </dependency>
     <dependency>
       <groupId>org.aaa4j.radius</groupId>
       <artifactId>aaa4j-radius-client</artifactId>
-      <version>0.3.0</version>
+      <version>${version.aaa4j}</version>
     </dependency>
   </dependencies>
 

--- a/wasp-core/src/main/resources/application-docker.properties
+++ b/wasp-core/src/main/resources/application-docker.properties
@@ -1,4 +1,0 @@
-# Database settings
-spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
-spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
-spring.datasource.url=${SPRING_DATASOURCE_URL}}

--- a/wasp-core/src/main/resources/application-local.properties
+++ b/wasp-core/src/main/resources/application-local.properties
@@ -1,7 +1,0 @@
-# Database settings
-spring.datasource.username=wasp
-spring.datasource.password=wasp
-spring.datasource.url=jdbc:postgresql://localhost:5432/wasp
-
-#
-logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG

--- a/wasp-core/src/main/resources/application.properties
+++ b/wasp-core/src/main/resources/application.properties
@@ -1,11 +1,9 @@
-spring.profiles.active=@spring.profiles.active@
-
 # GLOBAL SETTINGS
 
 #
 # App settings
 #
-spring.application.name=wasp-ng-core
+spring.application.name=wasp-core
 git.commitIdAbbrev=@git.commit.id.abbrev@
 git.branch=@git.branch@
 git.buildTime=@git.build.time@
@@ -24,7 +22,15 @@ wasp.radius.nas.ip=${WASP_RADIUS_NAS_IP:}
 spring.security.user.name=admin@wasp
 spring.security.user.password=$2a$10$kX0yrAZjba0eWKIG4ew.I.6KymZXILYJU5hbqpNRZFS3AeclumudO
 spring.security.user.roles=AUTHENTICATED_USER,USER_MANAGER,REPO_MANAGER,CONTENT_MANAGER
-
+#
+# Vault settings
+#
+spring.cloud.vault.enabled=${SPRING_CLOUD_VAULT_ENABLED:false}
+spring.cloud.vault.token=${SPRING_CLOUD_VAULT_TOKEN:wasp}
+spring.cloud.vault.scheme=${SPRING_CLOUD_VAULT_SCHEME:http}
+spring.cloud.vault.host=${SPRING_CLOUD_VAULT_HOST:localhost}
+spring.cloud.vault.kv.enabled=${SPRING_CLOUD_VAULT_KV_ENABLED:true}
+spring.config.import:optional:vault://
 #
 # Tomcat settings
 #
@@ -32,18 +38,18 @@ server.port=${SERVER_PORT:8888}
 server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=30s
 server.servlet.context-path=/wasp
-
 #
 # Thymeleaf settings
 #
 spring.thymeleaf.cache=false
 spring.thymeleaf.suffix=.html
-
 #
 # Database settings
 #
 spring.datasource.driver-class-name=org.postgresql.Driver
-
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:wasp}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:wasp}
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/wasp}
 #
 # JPA & Hibernate settings
 #


### PR DESCRIPTION
Added the possibility to read configuration parameters from the Hashicorp Vault. In addition, removed application profiles at all. May be, later I'll bring them back, but they are not needed for now.