### PR TITLE
#43 Persist the default administrative account in the DB

### DIFF
--- a/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/WaspCoreApplication.java
+++ b/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/WaspCoreApplication.java
@@ -6,10 +6,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.event.EventListener;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import ru.vsu.uic.wasp.ng.core.config.GitInfoProperties;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableJpaAuditing
 @Slf4j
 public class WaspCoreApplication {
 

--- a/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/config/DefaultUserRegistrar.java
+++ b/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/config/DefaultUserRegistrar.java
@@ -1,0 +1,111 @@
+package ru.vsu.uic.wasp.ng.core.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import ru.vsu.uic.wasp.ng.core.dao.entity.AuthenticationType;
+import ru.vsu.uic.wasp.ng.core.dao.entity.Role;
+import ru.vsu.uic.wasp.ng.core.dao.entity.User;
+import ru.vsu.uic.wasp.ng.core.dao.entity.UserStatus;
+import ru.vsu.uic.wasp.ng.core.dao.repository.AuthenticationTypeRepository;
+import ru.vsu.uic.wasp.ng.core.dao.repository.RoleRepository;
+import ru.vsu.uic.wasp.ng.core.dao.repository.UserRepository;
+import ru.vsu.uic.wasp.ng.core.dao.repository.UserStatusRepository;
+import ru.vsu.uic.wasp.ng.core.security.AccountStatus;
+import ru.vsu.uic.wasp.ng.core.security.WaspAuthType;
+import ru.vsu.uic.wasp.ng.core.security.WaspRole;
+
+import java.util.Optional;
+
+/**
+ * The component is responsible for registering the default administrative user defined in the application.properties.
+ * The registration is done only once if the user was not found in the database.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class DefaultUserRegistrar implements ApplicationListener<ContextRefreshedEvent> {
+
+    @Value("${spring.security.user.name}")
+    private String defaultAdminUserName;
+
+    @Value("${spring.security.user.password}")
+    private String defaultAdminPassword;
+
+    private final UserRepository userRepository;
+
+    private final RoleRepository roleRepository;
+
+    private final UserStatusRepository userStatusRepository;
+
+    private final AuthenticationTypeRepository authenticationTypeRepository;
+
+    private boolean defaultUserInitialised = false;
+
+    @Override
+    @Transactional
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        log.debug("Got event: {}", event);
+        if (!defaultUserInitialised) {
+            log.debug("Check if the default user was already registered...");
+            User defaultUser = userRepository.findByLogin(defaultAdminUserName);
+            if (defaultUser == null) {
+                log.debug("The default user was not registered.");
+                defaultUser = new User();
+                defaultUser.setLogin(defaultAdminUserName);
+                defaultUser.setPassword(defaultAdminPassword);
+                defaultUser.setFirstName("");
+                defaultUser.setLastName("");
+                Optional<UserStatus> activeUserStatus = userStatusRepository.findUserStatusByCode(
+                        AccountStatus.ACTIVE.toString());
+                // set the account status to the 'active'
+                if (activeUserStatus.isPresent()) {
+                    defaultUser.setStatus(activeUserStatus.get());
+                } else {
+                    throw new RuntimeException(
+                            "Not found the predefined account status in the database: " + AccountStatus.ACTIVE);
+                }
+                // set the authentication type to the 'internal'
+                Optional<AuthenticationType> internalAuthenticationType = authenticationTypeRepository.findAuthenticationTypeByCode(
+                        WaspAuthType.INT_WASP.toString());
+                if (internalAuthenticationType.isPresent()) {
+                    defaultUser.setAuthenticationType(internalAuthenticationType.get());
+                } else {
+                    throw new RuntimeException(
+                            "Not found the predefined authentication type in the database: " + WaspAuthType.INT_WASP);
+                }
+                // set all roles
+                for (WaspRole waspRole : WaspRole.values()) {
+                    Optional<Role> role = roleRepository.findRoleByCode(waspRole.toString());
+                    if (role.isPresent()) {
+                        // The AUTHENTICATED_USER role is granted dynamically for every authenticated user.
+                        // There is no need to grant the role here.
+                        if (!role.get().getCode().equals(WaspRole.AUTHENTICATED_USER.toString())) {
+                            defaultUser.addRole(role.get());
+                        }
+                    } else {
+                        throw new RuntimeException("Not found the predefined role in the database: " + waspRole);
+                    }
+                }
+                log.debug("The fully initialised default user: {}", defaultUser);
+                userRepository.save(defaultUser);
+                defaultUserInitialised = true;
+            } else {
+                log.debug(
+                        "The default user was found in the database. Looks like it was already initialised in the past.");
+                defaultUserInitialised = true;
+            }
+        } else {
+            log.debug("The default user was already initialised.");
+        }
+    }
+
+    @Override
+    public boolean supportsAsyncExecution() {
+        return ApplicationListener.super.supportsAsyncExecution();
+    }
+}

--- a/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/entity/AuthenticationType.java
+++ b/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/entity/AuthenticationType.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.Hibernate;
 
 import java.util.Objects;
@@ -15,6 +16,7 @@ import java.util.UUID;
 @Table(name = "auth_types")
 @Getter
 @Setter
+@ToString
 public class AuthenticationType {
 
     @Id

--- a/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/entity/Role.java
+++ b/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/entity/Role.java
@@ -1,15 +1,21 @@
 package ru.vsu.uic.wasp.ng.core.dao.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.ToString.Exclude;
 import org.hibernate.Hibernate;
 import org.springframework.security.core.GrantedAuthority;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -29,7 +35,22 @@ public class Role implements GrantedAuthority {
     @Column(name = "role_description", updatable = false)
     private String description;
 
-    public Role() {}
+    @OneToMany(
+            mappedBy = "role",
+            cascade = CascadeType.MERGE,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    @Exclude
+    private List<UserRole> users = new ArrayList<>();
+
+    public Role() {
+    }
+
+    @Override
+    public String getAuthority() {
+        return "ROLE_" + getCode();
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -46,10 +67,5 @@ public class Role implements GrantedAuthority {
     @Override
     public int hashCode() {
         return getClass().hashCode();
-    }
-
-    @Override
-    public String getAuthority() {
-        return "ROLE_" + getCode();
     }
 }

--- a/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/entity/UserRole.java
+++ b/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/entity/UserRole.java
@@ -1,0 +1,64 @@
+package ru.vsu.uic.wasp.ng.core.dao.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.Hibernate;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "users_roles")
+@Getter
+@Setter
+@ToString
+public class UserRole implements Serializable {
+
+    @EmbeddedId
+    private UserRoleId id = new UserRoleId();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("userId") // points to the property in the UserRoleId class referencing to the User entity.
+    @JoinColumn(name = "ref_users") // set the join column name, otherwise Hibernate will use user_id
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("roleId") // points to the property in the UserRoleId class referencing to the Role entity.
+    @JoinColumn(name = "ref_roles") // set the join column name, otherwise Hibernate will use role_id
+    private Role role;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) {
+            return false;
+        }
+        UserRole userRole = (UserRole) o;
+        return getId() != null && Objects.equals(getId(), userRole.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/entity/UserRoleId.java
+++ b/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/entity/UserRoleId.java
@@ -1,0 +1,29 @@
+package ru.vsu.uic.wasp.ng.core.dao.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * The class defines the composite primary key for the 'users_roles' table. The class is needed because the
+ * 'users_roles' table has additional columns and the usual @ManyToMany is not enough here. We need an additional entity
+ * (see UserRole) to handle the link between users and roles to keep the additional attributes.
+ */
+@Embeddable
+@Getter
+@Setter
+@EqualsAndHashCode
+public class UserRoleId implements Serializable {
+
+    @Column(name = "ref_users")
+    private UUID userId;
+    @Column(name = "ref_roles")
+    private UUID roleId;
+
+
+}

--- a/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/repository/AuthenticationTypeRepository.java
+++ b/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/repository/AuthenticationTypeRepository.java
@@ -1,0 +1,13 @@
+package ru.vsu.uic.wasp.ng.core.dao.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ru.vsu.uic.wasp.ng.core.dao.entity.AuthenticationType;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface AuthenticationTypeRepository extends JpaRepository<AuthenticationType, UUID> {
+
+    Optional<AuthenticationType> findAuthenticationTypeByCode(String code);
+
+}

--- a/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/repository/RoleRepository.java
+++ b/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/repository/RoleRepository.java
@@ -3,8 +3,11 @@ package ru.vsu.uic.wasp.ng.core.dao.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import ru.vsu.uic.wasp.ng.core.dao.entity.Role;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface RoleRepository extends JpaRepository<Role, UUID> {
+
+    Optional<Role> findRoleByCode(String code);
 
 }

--- a/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/repository/UserStatusRepository.java
+++ b/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/dao/repository/UserStatusRepository.java
@@ -1,0 +1,13 @@
+package ru.vsu.uic.wasp.ng.core.dao.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ru.vsu.uic.wasp.ng.core.dao.entity.UserStatus;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserStatusRepository extends JpaRepository<UserStatus, UUID> {
+
+    Optional<UserStatus> findUserStatusByCode(String code);
+
+}

--- a/wasp-core/src/main/resources/application.properties
+++ b/wasp-core/src/main/resources/application.properties
@@ -1,8 +1,6 @@
-# GLOBAL SETTINGS
-
-#
+# ======================================================================================================================
 # App settings
-#
+# ======================================================================================================================
 spring.application.name=wasp-core
 git.commitIdAbbrev=@git.commit.id.abbrev@
 git.branch=@git.branch@
@@ -16,67 +14,67 @@ wasp.radius.port=${WASP_RADIUS_PORT:1812}
 wasp.radius.secret=${WASP_RADIUS_SECRET:}
 wasp.radius.nas.identifier=${WASP_RADIUS_NAS_IDENTIFIER:wasp}
 wasp.radius.nas.ip=${WASP_RADIUS_NAS_IP:}
-#
+# ======================================================================================================================
 # Spring Security settings
-#
+# ======================================================================================================================
+# Default administrative username.
+# The use will be automatically created by the application.
 spring.security.user.name=admin@wasp
+# Default administrative password.
+# The password is a string encrypted by BCrypt algorithm.
 spring.security.user.password=$2a$10$kX0yrAZjba0eWKIG4ew.I.6KymZXILYJU5hbqpNRZFS3AeclumudO
-spring.security.user.roles=AUTHENTICATED_USER,USER_MANAGER,REPO_MANAGER,CONTENT_MANAGER
-#
+# ======================================================================================================================
 # Vault settings
-#
+# ======================================================================================================================
 spring.cloud.vault.enabled=${SPRING_CLOUD_VAULT_ENABLED:false}
 spring.cloud.vault.token=${SPRING_CLOUD_VAULT_TOKEN:wasp}
 spring.cloud.vault.scheme=${SPRING_CLOUD_VAULT_SCHEME:http}
 spring.cloud.vault.host=${SPRING_CLOUD_VAULT_HOST:localhost}
 spring.cloud.vault.kv.enabled=${SPRING_CLOUD_VAULT_KV_ENABLED:true}
 spring.config.import:optional:vault://
-#
+# ======================================================================================================================
 # Tomcat settings
-#
+# ======================================================================================================================
 server.port=${SERVER_PORT:8888}
 server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=30s
 server.servlet.context-path=/wasp
-#
+# ======================================================================================================================
 # Thymeleaf settings
-#
+# ======================================================================================================================
 spring.thymeleaf.cache=false
 spring.thymeleaf.suffix=.html
-#
+# ======================================================================================================================
 # Database settings
-#
+# ======================================================================================================================
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:wasp}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:wasp}
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/wasp}
-#
+# ======================================================================================================================
 # JPA & Hibernate settings
-#
+# ======================================================================================================================
 spring.jpa.database=postgresql
 spring.jpa.properties.hibernate.default_schema=core
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.ddl-auto=none
-
-#
+# ======================================================================================================================
 # Liquibase settings
-#
+# ======================================================================================================================
 spring.liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
 spring.liquibase.default-schema=${wasp.core.db.schema}
 spring.liquibase.drop-first=false
-
-#
+# ======================================================================================================================
 # Logging settings
-#
+# ======================================================================================================================
 logging.level.ru.vsu.uic.wasp.ng=debug
 logging.level.org.hibernate.orm.jdbc.bind=trace
 logging.level.org.springframework.transaction.support=debug;
 logging.level.org.springframework.security=trace
-
-#
+# ======================================================================================================================
 # Actuator settings
-#
+# ======================================================================================================================
 management.server.port=${MANAGEMENT_SERVER_PORT:8889}
 
 # Disables all endpoints

--- a/wasp-core/src/main/resources/db/changelog/changes/20240801-06_wasp-core_create-table-users-roles.xml
+++ b/wasp-core/src/main/resources/db/changelog/changes/20240801-06_wasp-core_create-table-users-roles.xml
@@ -8,17 +8,16 @@
   <changeSet id="20240801-07" author="eryzhkov">
 
     <createTable tableName="users_roles" schemaName="core" remarks="The roles assigned to a user.">
-      <column name="id" type="java.util.UUID" defaultValueComputed="uuid_generate_v4()" remarks="The unique identifier.">
-        <constraints primaryKey="true" primaryKeyName="pk_users_roles" nullable="false"/>
-      </column>
       <column name="created_at" type="java.sql.Types.TIMESTAMP_WITH_TIMEZONE" remarks="When a role was assigned.">
         <constraints nullable="false"/>
       </column>
       <column name="ref_roles" type="JAVA.UTIL.UUID" remarks="A reference to the role.">
-        <constraints nullable="false" referencedTableSchemaName="core" referencedTableName="roles" referencedColumnNames="id" foreignKeyName="fk_roles"/>
+        <constraints primaryKey="true" primaryKeyName="pk_users_roles" nullable="false" referencedTableSchemaName="core"
+          referencedTableName="roles" referencedColumnNames="id" foreignKeyName="fk_roles"/>
       </column>
       <column name="ref_users" type="JAVA.UTIL.UUID" remarks="A reference to the user.">
-        <constraints nullable="false" referencedTableSchemaName="core" referencedTableName="users" referencedColumnNames="id" foreignKeyName="fk_users"/>
+        <constraints primaryKey="true" primaryKeyName="pk_users_roles" nullable="false" referencedTableSchemaName="core"
+          referencedTableName="users" referencedColumnNames="id" foreignKeyName="fk_users"/>
       </column>
     </createTable>
 


### PR DESCRIPTION
Changes:
- removed the column 'id' from the 'users_roles' table;
- added the UserRoleId entity as embedded class;
- added the entity UserRole to manager a link between User and Role;
- added the corresponding repositories;
- added new link to the User entity (the entity manages the link);
- added the new link to the Role entity;
- added the DefaultUserRegistrar class to initialize the default user using the application.properties;
- added JPA audit capabilities.