### PR TITLE
#47 Change the default names for Liquibase tables

### DIFF
--- a/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/security/WaspAuthenticationProvider.java
+++ b/wasp-core/src/main/java/ru/vsu/uic/wasp/ng/core/security/WaspAuthenticationProvider.java
@@ -39,7 +39,7 @@ public class WaspAuthenticationProvider implements AuthenticationProvider {
     @Value("${spring.security.user.password}")
     private String embeddedAdminPassword;
 
-    @Value("${spring.security.user.roles}")
+    @Value("${spring.security.user.roles:}")
     private String embeddedAdminRoles;
 
     private final UserRepository userRepository;

--- a/wasp-core/src/main/resources/application.properties
+++ b/wasp-core/src/main/resources/application.properties
@@ -64,6 +64,8 @@ spring.jpa.hibernate.ddl-auto=none
 # ======================================================================================================================
 spring.liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
 spring.liquibase.default-schema=${wasp.core.db.schema}
+spring.liquibase.database-change-log-table=lb_databasechangelog
+spring.liquibase.database-change-log-lock-table=lb_databasechangeloglock
 spring.liquibase.drop-first=false
 # ======================================================================================================================
 # Logging settings


### PR DESCRIPTION
Set new table names in the application.properties. Fixed bug in the WaspAuthenticationProvider.